### PR TITLE
Fixed PW-2, fixed the scroll issue with OrbitalControls

### DIFF
--- a/src/components/Nblocks3DLogo.astro
+++ b/src/components/Nblocks3DLogo.astro
@@ -10,6 +10,8 @@
 
   import type { CameraSettings } from "../utils/threejs/createCamera";
 
+  import enableMobileTouchAction from "../utils/threejs/enableMobielTouchAction";
+
   const main = async () => {
     // Get a reference to the container element
     const container = document.getElementById(
@@ -19,10 +21,18 @@
       fov: 50,
       position: { x: -2, y: 1, z: 4 },
     };
+
     // Crate a new World
-    const world = new World(container, undefined, camneraSettings, undefined, {
-      autoRotate: true,
-    });
+    const world = new World(
+      container,
+      undefined,
+      camneraSettings,
+      undefined,
+      {
+        autoRotate: true,
+      },
+      enableMobileTouchAction
+    );
 
     world.init = async () => {
       // Load models

--- a/src/components/Northwhistle3DPhoneMocup.astro
+++ b/src/components/Northwhistle3DPhoneMocup.astro
@@ -10,6 +10,8 @@
 
   import type { CameraSettings } from "../utils/threejs/createCamera";
 
+  import enableMobileTouchAction from "../utils/threejs/enableMobielTouchAction";
+
   const main = async () => {
     // Get a reference to the container element
     const container = document.getElementById(
@@ -20,13 +22,19 @@
       position: { x: -2, y: -1, z: 4 },
     };
     // Crate a new World
-    const world = new World(container, undefined, camneraSettings, undefined, {
-      autoRotate: true,
-    });
+    const world = new World(
+      container,
+      undefined,
+      camneraSettings,
+      undefined,
+      {
+        autoRotate: true,
+      },
+      enableMobileTouchAction
+    );
 
     // Modify world light
     world.lights.ambientLight.intensity = 0.4;
-    console.log(world.lights.ambientLight.intensity);
 
     world.init = async () => {
       // Load models

--- a/src/utils/threejs/Loop.ts
+++ b/src/utils/threejs/Loop.ts
@@ -1,5 +1,4 @@
 import * as THREE from "three";
-import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import type { GLTF } from "three/examples/jsm/loaders/GLTFLoader";
 import type { Controls } from "./createControls";
 

--- a/src/utils/threejs/Resizer.ts
+++ b/src/utils/threejs/Resizer.ts
@@ -13,19 +13,23 @@ const setSize = (container: HTMLElement, camera: THREE.PerspectiveCamera, render
   };
 
 class Resizer {
-    constructor(container: HTMLElement, camera: THREE.PerspectiveCamera, renderer: THREE.WebGLRenderer) {
+    onResizeCallback?: () => void;
+
+    constructor(container: HTMLElement, camera: THREE.PerspectiveCamera, renderer: THREE.WebGLRenderer, onResizeCallback?: () => void) {
       setSize(container, camera, renderer);
+      this.onResizeCallback = onResizeCallback;
   
       window.addEventListener("resize", () => {
         // set the size again if a resize occurs
         setSize(container, camera, renderer);
-  
         // perform any custom actions
-        this.onResize();
+        if (onResizeCallback) (this.onResize(onResizeCallback));
       });
     }
   
-    onResize() {}
+    onResize(onResizeCallback: () => void) {
+      onResizeCallback();
+    }
   }
 
 

--- a/src/utils/threejs/World.ts
+++ b/src/utils/threejs/World.ts
@@ -44,7 +44,8 @@ class World implements WorldReference {
     color?: ColorRepresentation,
     cameraSettings?: CameraSettings,
     rendererSettings?: THREE.WebGLRendererParameters,
-    controlSettings?: ControlSettings
+    controlSettings?: ControlSettings,
+    resizerCallback?: () => void
   ) {
     // synchronous setup here
     // create camera, renderer, scene, etc..
@@ -62,16 +63,15 @@ class World implements WorldReference {
     this.loop = new Loop(this.camera, this.scene, this.renderer);
     this.loop.updatables.push(this.controls);
 
+    this.renderer.domElement.classList.add("scene");
     container.appendChild(this.renderer.domElement);
 
-    this.resizer = new Resizer(container, this.camera, this.renderer);
+    this.resizer = new Resizer(container, this.camera, this.renderer, resizerCallback);
   }
 
   async init() {
     // asynchronous setup here
     // e.g loading models
-    // Moce the target to the center of the bird
-    // this.controls.target.copy(this.testCube.position);
   }
 
   render() {
@@ -80,6 +80,9 @@ class World implements WorldReference {
   }
 
   start() {
+    // Run custom resize callback before first frame
+    if (this.resizer.onResizeCallback) this.resizer.onResize(this.resizer.onResizeCallback);
+    // Start loop
     this.loop.start();
   }
 

--- a/src/utils/threejs/createControls.ts
+++ b/src/utils/threejs/createControls.ts
@@ -8,19 +8,22 @@ export interface Controls extends OrbitControls {
 export type ControlSettings = {
   enableDamping?: boolean;
   autoRotate?: boolean;
+  enabled?: true
 };
 
+// Takes configuration and returns Controls
 const createControls = (
   camera: PerspectiveCamera,
   canvas: HTMLCanvasElement,
   controlSettings?: ControlSettings
 ): Controls => {
   const defaultControlSettings = {
+    enabled: true,
     enableDamping: true,
     autoRotate: false,
   };
 
-  const { enableDamping, autoRotate } = {
+  const { enableDamping, autoRotate, enabled} = {
     ...defaultControlSettings,
     ...controlSettings,
   };
@@ -28,6 +31,8 @@ const createControls = (
   const controls = new OrbitControls(camera, canvas);
   controls.enableDamping = enableDamping;
   controls.autoRotate = autoRotate;
+  controls.enabled = enabled;
+  controls.update();
   return {
     ...controls,
     tick: () => {

--- a/src/utils/threejs/enableMobielTouchAction.ts
+++ b/src/utils/threejs/enableMobielTouchAction.ts
@@ -1,0 +1,22 @@
+/* 
+  Three.js's OrbitalControls class sets the following inline style within its constructor method
+  It is a very case specific option which interfiers with touch scroll on mobile, therefore I have wrote this script which removes it
+  based on screen size.
+  touch-action: none;
+} */
+
+
+const enableMobileTouchAction = () => {
+  const mediaQuery = window.matchMedia("(max-width: 768px)");
+  const canvas = document.getElementsByClassName("scene")[0] as HTMLElement;
+  switch (mediaQuery.matches) {
+    case true:
+      canvas.style.touchAction = "pan-y";
+      break;
+    case false:
+      canvas.style.touchAction = "none";
+      break;
+  }
+};
+
+export default enableMobileTouchAction;


### PR DESCRIPTION
Fixed the issue with Orbital Controls preventing the scroll on mobile devices. Problem was caused the the OrbitalControls constructor method which adds inline style to passed canvas node.  The style it adds that caused this issue was _touch-action: "none"_. I wrote a simple callback interface which allows me to check on resize of the screen and 'first frame print' the size of the screen on which the website is showcased, based on this I enable or disable the touch action.