### PR TITLE
[docker] Bump node from 18-buster to 20-buster in /.devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:18-buster AS builder
+FROM node:20-buster AS builder
 SHELL ["/bin/bash", "-c"]
 
 


### PR DESCRIPTION
Bumps node from 18-buster to 20-buster.

---
updated-dependencies:
- dependency-name: node dependency-type: direct:production ...